### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ public function behaviors()
 ```php
 'urlManager' => [
     'rules' => [
-        '/<id:sitemap.xml>' => 'sitemap/default/index',
+        ['pattern' => 'sitemap', 'route' => 'sitemap/default/index', 'suffix' => '.xml'],
     ],
 ],
 ```


### PR DESCRIPTION
The recommended sitemap route will not work correctly if the "suffix" parameter is specified among the UrlManager parameters. It is possible to fix by specifying a suffix for the sitemap route (".xml").
